### PR TITLE
Config validation

### DIFF
--- a/includes/classes/ConfigParser.hpp
+++ b/includes/classes/ConfigParser.hpp
@@ -32,8 +32,9 @@ class	ConfigParser
 		ConfigParser(void);
 		~ConfigParser(void);
 
-		static void							_loadServerContext(std::ifstream &configFile);
-		static void							_overrideDefaults(void);
+		static void	_loadServerContext(std::ifstream &configFile);
+		static void	_overrideDefaults(void);
+		static void	_validateConfigs(const ServerBlocks configs);
 
   		static std::vector<std::string>	_strServerBlock;
 };

--- a/sources/classes/ConfigParser.cpp
+++ b/sources/classes/ConfigParser.cpp
@@ -237,8 +237,11 @@ void	ConfigParser::_validateConfigs(const ServerBlocks configs)
 			{
 				for (size_t k = 0; k < configs.at(i).getServerNamesSize(); k++)
 				{
-					if (configs.at(i).getServerName(k) == configs.at(j).getServerName(k))
-						throw ("Found conflicting servernames for virtual servers with same host and port")
+					for (size_t l = 0; l < configs.at(j).getServerNamesSize(); l++)
+					{
+						if (configs.at(i).getServerName(k) == configs.at(j).getServerName(l) )
+						throw (ExceptionMaker("Found conflicting servernames for virtual servers with same host and port") );
+					}
 				}
 			}
 		}

--- a/sources/classes/ConfigParser.cpp
+++ b/sources/classes/ConfigParser.cpp
@@ -74,6 +74,7 @@ void	ConfigParser::parseConfigs(const char *path, ServerBlocks &configs)
 	if (configs.empty() )
 		throw (ExceptionMaker("Configuration file is empty") );
 
+	_validateConfigs(configs);
 
 //	THIS IS FOR DEBUGGING ONLY
 	for (size_t i = 0; i < configs.size(); i++)
@@ -220,4 +221,11 @@ void	ConfigParser::_overrideDefaults(void)
 				throw (ExceptionMaker("Invalid argument in \"autoindex\" directive in server context") );
 		}
 	}
+}
+
+void	ConfigParser::_validateConfigs(const ServerBlocks configs)
+{
+	//	TWO SERVERS CANNOT BE LISTENING ON THE SAME HOST:PORT PAIR
+	//	TWO SERVERS CANNOT HAVE THE SAME NAME(?)
+	//	NO DUPLICATES IN allowedMetods
 }

--- a/sources/classes/ConfigParser.cpp
+++ b/sources/classes/ConfigParser.cpp
@@ -225,7 +225,31 @@ void	ConfigParser::_overrideDefaults(void)
 
 void	ConfigParser::_validateConfigs(const ServerBlocks configs)
 {
-	//	TWO SERVERS CANNOT BE LISTENING ON THE SAME HOST:PORT PAIR
-	//	TWO SERVERS CANNOT HAVE THE SAME NAME(?)
-	//	NO DUPLICATES IN allowedMetods
+	size_t	vectorSize;
+
+	vectorSize = configs.size();
+	for (size_t i = 0; i < vectorSize; i++)
+	{
+		for (size_t j = i + 1; j < vectorSize; j++)
+		{
+			if (configs.at(i).getHost() == configs.at(j).getHost() \
+				&& configs.at(i).getPort() == configs.at(j).getPort() )
+			{
+				for (size_t k = 0; k < configs.at(i).getServerNamesSize(); k++)
+				{
+					if (configs.at(i).getServerName(k) == configs.at(j).getServerName(k))
+						throw ("Found conflicting servernames for virtual servers with same host and port")
+				}
+			}
+		}
+
+		for (size_t j = 0; j < configs.at(i).getLocationBlocksSize(); j++)
+		{
+			for (size_t k = j + 1; k < configs.at(i).getLocationBlocksSize(); k++)
+			{
+				if (configs.at(i).getLocationFromIndex(j)->getLocation() == configs.at(i).getLocationFromIndex(k)->getLocation() )
+					throw (ExceptionMaker("Duplicate location found") );
+			}
+		}
+	}
 }

--- a/sources/classes/ServerLocation.cpp
+++ b/sources/classes/ServerLocation.cpp
@@ -360,11 +360,23 @@ void	ServerLocation::_setAllowedMethods(std::vector<std::string> strLocationBloc
 			while (strStream >> method)
 			{
 				if (method == "GET")
+				{
+					if (std::find(methodsAllowed.begin(), methodsAllowed.end(), Http::M_GET) != methodsAllowed.end() )
+						throw (ExceptionMaker("Duplicate method found in \"allow_methods\" directive") );
 					methodsAllowed.push_back(Http::M_GET);
+				}
 				else if (method == "POST")
+				{
+					if (std::find(methodsAllowed.begin(), methodsAllowed.end(), Http::M_POST) != methodsAllowed.end() )
+						throw (ExceptionMaker("Duplicate method found in \"allow_methods\" directive") );
 					methodsAllowed.push_back(Http::M_POST);
+				}
 				else if (method == "DELETE")
+				{
+					if (std::find(methodsAllowed.begin(), methodsAllowed.end(), Http::M_DELETE) != methodsAllowed.end() )
+						throw (ExceptionMaker("Duplicate method found in \"allow_methods\" directive") );
 					methodsAllowed.push_back(Http::M_DELETE);
+				}
 				else
 					throw (ExceptionMaker("Invalid argument in \"allow_methods\" directive") );
 			}
@@ -380,11 +392,23 @@ void	ServerLocation::_setAllowedMethods(std::vector<std::string> strLocationBloc
 			for (size_t i = 0; i < ConfigParser::defaultMethodsAllowed.size(); i++)
 			{
 				if (ConfigParser::defaultMethodsAllowed.at(i) == "GET")
+				{
+					if (std::find(methodsAllowed.begin(), methodsAllowed.end(), Http::M_GET) != methodsAllowed.end() )
+						throw (ExceptionMaker("Duplicate method found in \"allow_methods\" directive") );
 					methodsAllowed.push_back(Http::M_GET);
+				}
 				else if (ConfigParser::defaultMethodsAllowed.at(i) == "POST")
+				{
+					if (std::find(methodsAllowed.begin(), methodsAllowed.end(), Http::M_POST) != methodsAllowed.end() )
+						throw (ExceptionMaker("Duplicate method found in \"allow_methods\" directive") );
 					methodsAllowed.push_back(Http::M_POST);
+				}
 				else if (ConfigParser::defaultMethodsAllowed.at(i) == "DELETE")
+				{
+					if (std::find(methodsAllowed.begin(), methodsAllowed.end(), Http::M_DELETE) != methodsAllowed.end() )
+						throw (ExceptionMaker("Duplicate method found in \"allow_methods\" directive") );					
 					methodsAllowed.push_back(Http::M_DELETE);
+				}
 				else
 					throw (ExceptionMaker("Invalid argument in \"allow_methods\" directive in server context") );
 			}

--- a/test_files/configs/test.conf
+++ b/test_files/configs/test.conf
@@ -16,7 +16,7 @@ server
 		client_max_body_size 100050;
 	}
 
-	allow_methods DELETE POST GET;
+	allow_methods DELETE GET;
 	client_max_body_size 20000;
 	rewrite anonfiles.com anonfiles.con;
 

--- a/test_files/configs/test.conf
+++ b/test_files/configs/test.conf
@@ -16,7 +16,6 @@ server
 		client_max_body_size 100050;
 	}
 
-	
 	allow_methods DELETE POST GET;
 	client_max_body_size 20000;
 	rewrite anonfiles.com anonfiles.con;
@@ -32,3 +31,4 @@ server
 
 	error_page 500 /this/is/a/custom/default;
 }
+


### PR DESCRIPTION
Implemented post-parsing validation of loaded configs.
The foolowing are not allowed:
* virtual servers with same host, port and servername
* duplicate locations
* duplicate methods in allow_methods directive