### PR TITLE
servername feature implemented

### DIFF
--- a/includes/classes/ServerManager.hpp
+++ b/includes/classes/ServerManager.hpp
@@ -45,5 +45,5 @@ class ServerManager
 		bool				evU64IsSock(long const& evU64)		throw();
 		void				writeEvent(epoll_event & trigEv)	throw();
 		void				readEvent(epoll_event & trigEv)		throw();
-		ServerConfig const&	getServerFromSocket(int const& socket_fd);
+		ServerConfig const	getServerFromSocket(int const& socket_fd, Request const &request);
 };

--- a/public/elpollobandito/index.txt
+++ b/public/elpollobandito/index.txt
@@ -1,0 +1,1 @@
+there's nothing here for you

--- a/test_files/configs/test.conf
+++ b/test_files/configs/test.conf
@@ -5,7 +5,7 @@ server
 	listen 0.0.0.0:4242;
 
 	root ./public;
-	server_name webserv.ft senorpollosdomain.epb;
+	server_name webserv.ft;
 	allow_methods GET POST;
 
 	location / {
@@ -38,6 +38,8 @@ server
 {
 	listen 0.0.0.0:4243;
 
+	server_name	lexasdomain.epb;
+
 	root ./public/lexa;
 	allow_methods GET;
 
@@ -45,5 +47,23 @@ server
 	{
 		autoindex off;
 		index hakkd.html;
+	}
+}
+
+
+
+server
+{
+	listen 0.0.0.0:4242;
+
+	server_name	senorpollosdomain.epb;
+
+	root ./public/elpollobandito;
+	allow_methods GET;
+
+	location /
+	{
+		autoindex off;
+		index index.txt;
 	}
 }


### PR DESCRIPTION
_servername_ can now be specified in the request. This can be tested with curl, like
`curl [servername]:[port]`

_servername_ must be set in /etc/hosts of the client