### PR TITLE
fixed segfault caused by missing _matchedLocation

### DIFF
--- a/includes/classes/Response.hpp
+++ b/includes/classes/Response.hpp
@@ -32,6 +32,7 @@ class Response {
 		Request					_request;
 		ServerConfig const &	_serverConfigs;
 		ServerLocation *		_locationMatch;
+		ServerLocation *		_defaultLocation;
 		std::string				_redirectionPath;
 		CGIMatch 				_cgiMatch;
 		

--- a/includes/classes/ServerLocation.hpp
+++ b/includes/classes/ServerLocation.hpp
@@ -5,7 +5,7 @@
 
 
 #define DEFAULT_LOCATION "/"
-#define DEFAULT_ROOT "./test_files"
+#define DEFAULT_ROOT "./public"
 #define DEFAULT_INDEX "index.html"
 #define DEFAULT_MAX_BODY_SIZE 1000000
 

--- a/sources/classes/Response.cpp
+++ b/sources/classes/Response.cpp
@@ -58,18 +58,21 @@ void Response::setMatchedLocation()
     }
 
     if (bestMatch == NULL)
-        throw ExceptionMaker("No valid location block found for the requested URI.");
+        bestMatch = this->_defaultLocation;
 
     _locationMatch = bestMatch;
-    LOG("Matched location:", Utils::LOG_INFO);
-    std::cout << *_locationMatch << std::endl;
+	LOG("Matched location:", Utils::LOG_INFO);
+	std::cout << *_locationMatch << std::endl;
 }
 
 /**************************************************************************/
 
 /**********************  CONSTRUCTORS / DESTRUCTORS ***********************/
 
-Response::~Response() {}
+Response::~Response() 
+{
+	delete this->_defaultLocation;
+}
 
 Response::Response(Request const &request, ServerConfig const &configs)
     : _statusCode(Http::SC_OK),
@@ -77,7 +80,8 @@ Response::Response(Request const &request, ServerConfig const &configs)
       _body(),
       _response(),
       _request(request),
-      _serverConfigs(configs)
+      _serverConfigs(configs),
+      _defaultLocation(new ServerLocation)
 {
 	if (this->_request.flag() != _EMPTY)
     {

--- a/sources/classes/ServerLocation.cpp
+++ b/sources/classes/ServerLocation.cpp
@@ -7,12 +7,14 @@ ServerLocation::ServerLocation(void)
 	this->_rootDir = DEFAULT_ROOT;
 	this->_indexFiles.push_back(DEFAULT_INDEX);
 	this->_maxBodySize = DEFAULT_MAX_BODY_SIZE;
+	this->_errorPages[400] = DEFAULT_400;
+	this->_errorPages[403] = DEFAULT_403;
 	this->_errorPages[404] = DEFAULT_404;
 	this->_errorPages[405] = DEFAULT_405;
 	this->_errorPages[500] = DEFAULT_500;
-	
+	this->_errorPages[501] = DEFAULT_501;
+
 	this->_methodsAllowed.push_back(Http::M_GET);
-	this->_methodsAllowed.push_back(Http::M_POST);
 	this->_autoIndex = false;
 }
 

--- a/test_files/configs/test2.conf
+++ b/test_files/configs/test2.conf
@@ -2,7 +2,7 @@
 
 server
 {
-	listen 127.0.0.1:4242;
+	listen 0.0.0.0:4242;
 
 	root ./public;
 


### PR DESCRIPTION
Title

When no location could be found for a URI, _locationMatch in Response would remain NULL.
webserv would segfault when trying to get the path to page 404 from a NULL pointer.

The setMatchedLocation mathod now assigns a pointer to a default ServerLocation object to _locationMatch if no location is found in the URI